### PR TITLE
[REFACT] Replace obsolete function IsBadReadPtr

### DIFF
--- a/libpeconv/include/peconv/util.h
+++ b/libpeconv/include/peconv/util.h
@@ -21,5 +21,12 @@ namespace peconv {
     Wrapper for GetProcessId - for a backward compatibility with old versions of Windows
     */
     DWORD get_process_id(HANDLE hProcess);
+
+    /**
+    Verifies that the calling process has read access to the specified range of memory.
+    \param lp : A pointer to the first byte of the memory block
+    \param ucb : The size of the memory block, in bytes. If this parameter is zero, the return value is zero.
+    */
+    bool is_bad_read_ptr(LPCVOID lp, SIZE_T ucb);
 };
 

--- a/libpeconv/src/exports_lookup.cpp
+++ b/libpeconv/src/exports_lookup.cpp
@@ -1,4 +1,5 @@
 #include "peconv/exports_lookup.h"
+#include "peconv/util.h"
 
 #include <iostream>
 
@@ -88,7 +89,7 @@ size_t peconv::get_exported_names(PVOID modulePtr, std::vector<std::string> &nam
         DWORD* nameRVA = (DWORD*)(funcNamesListRVA + (BYTE*) modulePtr + i * sizeof(DWORD));
        
         LPSTR name = (LPSTR)(*nameRVA + (BYTE*) modulePtr);
-        if (IsBadReadPtr(name, 1)) break; // this shoudld not happen. maybe the PE file is corrupt?
+        if (peconv::is_bad_read_ptr(name, 1)) break; // this shoudld not happen. maybe the PE file is corrupt?
 
         names_list.push_back(name);
     }
@@ -114,7 +115,7 @@ FARPROC peconv::get_exported_func(PVOID modulePtr, LPSTR wanted_name)
         const DWORD ordinal = MASK_TO_DWORD((ULONG_PTR)wanted_name);
         return get_export_by_ord(modulePtr, exp, ordinal);
     }
-    if (IsBadReadPtr(wanted_name, 1)) {
+    if (peconv::is_bad_read_ptr(wanted_name, 1)) {
         std::cerr << "[-] Invalid pointer to the name" << std::endl;
         return NULL;
     }
@@ -154,7 +155,7 @@ FARPROC peconv::export_based_resolver::resolve_func(LPSTR lib_name, LPSTR func_n
 
     if (hProc == NULL) {
 #ifdef _DEBUG
-        if (!IsBadReadPtr(func_name, 1)) {
+        if (!peconv::is_bad_read_ptr(func_name, 1)) {
             std::cerr << "[!] Cound not get the function: "<< func_name <<" from exports!" << std::endl;
         } else {
             std::cerr << "[!] Cound not get the function: "<< MASK_TO_DWORD((ULONG_PTR)func_name) <<" from exports!" << std::endl;
@@ -182,7 +183,7 @@ LPSTR peconv::read_dll_name(HMODULE modulePtr)
         return NULL;
     }
     LPSTR module_name = (char*)((ULONGLONG)modulePtr + exp->Name);
-    if (IsBadReadPtr(module_name, 1)) {
+    if (peconv::is_bad_read_ptr(module_name, 1)) {
         return NULL;
     }
     size_t len = peconv::forwarder_name_len((BYTE*) module_name);

--- a/libpeconv/src/file_util.cpp
+++ b/libpeconv/src/file_util.cpp
@@ -1,5 +1,6 @@
 #include "peconv/file_util.h"
 #include "peconv/buffer_util.h"
+#include "peconv/util.h"
 
 #include <fstream>
 #ifdef _DEBUG
@@ -37,7 +38,7 @@ peconv::ALIGNED_BUF peconv::load_file(IN const char *filename, OUT size_t &read_
     if (read_size != 0 && read_size <= r_size) {
         r_size = read_size;
     }
-    if (IsBadReadPtr(dllRawData, r_size)) {
+    if (peconv::is_bad_read_ptr(dllRawData, r_size)) {
         std::cerr << "[-] Mapping of " << filename << " is invalid!" << std::endl;
         UnmapViewOfFile(dllRawData);
         CloseHandle(mapping);

--- a/libpeconv/src/hooks.cpp
+++ b/libpeconv/src/hooks.cpp
@@ -81,7 +81,7 @@ bool PatchBackup::applyBackup()
 FARPROC peconv::hooking_func_resolver::resolve_func(LPSTR lib_name, LPSTR func_name)
 {
     //the name may be ordinal rather than string, so check if it is a valid pointer:
-    if (!IsBadReadPtr(func_name, 1)) {
+    if (!peconv::is_bad_read_ptr(func_name, 1)) {
         std::map<std::string, FARPROC>::iterator itr = hooks_map.find(func_name);
         if (itr != hooks_map.end()) {
             FARPROC hook = itr->second;

--- a/libpeconv/src/pe_hdrs_helper.cpp
+++ b/libpeconv/src/pe_hdrs_helper.cpp
@@ -1,4 +1,5 @@
 #include "peconv/pe_hdrs_helper.h"
+#include "peconv/util.h"
 
 using namespace peconv;
 
@@ -16,7 +17,7 @@ BYTE* peconv::get_nt_hdrs(IN const BYTE *pe_buffer, IN OPTIONAL size_t buffer_si
             return nullptr;
         }
     }
-    if (IsBadReadPtr(idh, sizeof(IMAGE_DOS_HEADER))) {
+    if (peconv::is_bad_read_ptr(idh, sizeof(IMAGE_DOS_HEADER))) {
         return nullptr;
     }
     if (idh->e_magic != IMAGE_DOS_SIGNATURE) {
@@ -33,7 +34,7 @@ BYTE* peconv::get_nt_hdrs(IN const BYTE *pe_buffer, IN OPTIONAL size_t buffer_si
             return nullptr;
         }
     }
-    if (IsBadReadPtr(inh, sizeof(IMAGE_NT_HEADERS32))) {
+    if (peconv::is_bad_read_ptr(inh, sizeof(IMAGE_NT_HEADERS32))) {
         return nullptr;
     }
     if (inh->Signature != IMAGE_NT_SIGNATURE) {
@@ -106,7 +107,7 @@ WORD peconv::get_nt_hdr_architecture(IN const BYTE *pe_buffer)
     if (!ptr) return 0;
 
     IMAGE_NT_HEADERS32 *inh = static_cast<IMAGE_NT_HEADERS32*>(ptr);
-    if (IsBadReadPtr(inh, sizeof(IMAGE_NT_HEADERS32))) {
+    if (peconv::is_bad_read_ptr(inh, sizeof(IMAGE_NT_HEADERS32))) {
         return 0;
     }
     return inh->OptionalHeader.Magic;

--- a/libpeconv/src/util.cpp
+++ b/libpeconv/src/util.cpp
@@ -98,3 +98,16 @@ bool peconv::is_padding(const BYTE *cave_ptr, size_t cave_size, const BYTE paddi
     }
     return true;
 }
+
+bool peconv::is_bad_read_ptr(LPCVOID lp, SIZE_T ucb)
+{ 
+  MEMORY_BASIC_INFORMATION mbi = { 0 };
+
+  if (!ucb) return false;
+  
+  if (VirtualQuery(lp, &mbi, ucb)) {
+      return (mbi.Protect & (PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY)) != 0 
+          && (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) == 0;
+  }
+  return true;
+}


### PR DESCRIPTION
hi there, I refactored some of your code that uses the obsolete function `IsBadReadPtr` to instead use a wrapper around `VirtualQuery` which has the same usage semantics. it should be a little safer (e.g. it won't trip PAGE_GUARD, among other various issues that function causes, see https://devblogs.microsoft.com/oldnewthing/20060927-07/?p=29563)

I put it in util.cpp, but wasn't sure if that was the best place.

let me know if I should make any changes. 