### PR TITLE
[BUGFIX] Wrapped ReadProcessMemory in a condition to avoid crash

### DIFF
--- a/libpeconv/src/remote_pe_reader.cpp
+++ b/libpeconv/src/remote_pe_reader.cpp
@@ -98,7 +98,6 @@ namespace peconv {
             if (ReadProcessMemory(processHandle, start_addr, buffer, last_success_size, &read_size)) {
             	return read_size;
             }
-            return read_size;
         }
         return 0;
     }

--- a/libpeconv/src/remote_pe_reader.cpp
+++ b/libpeconv/src/remote_pe_reader.cpp
@@ -95,7 +95,9 @@ namespace peconv {
         if (last_success_size) {
             read_size = 0;
             memset(buffer, 0, buffer_size);
-            ReadProcessMemory(processHandle, start_addr, buffer, last_success_size, &read_size);
+            if (ReadProcessMemory(processHandle, start_addr, buffer, last_success_size, &read_size)) {
+            	return read_size;
+            }
             return read_size;
         }
         return 0;


### PR DESCRIPTION
Hi @hasherezade,

This change will fix the issue for when PEsieve is used as a library in a separate thread.

Terry