### PR TITLE
Function table fix

### DIFF
--- a/libpeconv/src/exceptions_parser.cpp
+++ b/libpeconv/src/exceptions_parser.cpp
@@ -492,7 +492,7 @@ namespace details {
         while (NT_SUCCESS(RtlFindMemoryBlockFromModuleSection(hNtdll, lpSectionName, &SearchContext))) {
             PRTL_INVERTED_FUNCTION_TABLE_WIN7_32 tab = reinterpret_cast<decltype(tab)>(SearchContext.Result - Offset);
 
-            //Note: Same memory layout for RTL_INVERTED_FUNCTION_TABLE_ENTRY in Windows 10 x86 and x64.
+            //Note: Same memory layout for RTL_INVERTED_FUNCTION_TABLE_ENTRY in Windows 8 x86 and x64.
             if (RtlIsWindowsVersionOrGreater(6, 2, 0) && tab->MaxCount == 0x200 && !tab->NextEntrySEHandlerTableEncoded) return tab;
             else if (tab->MaxCount == 0x200 && !tab->Overflow) return tab;
         }

--- a/libpeconv/src/exceptions_parser.cpp
+++ b/libpeconv/src/exceptions_parser.cpp
@@ -470,7 +470,7 @@ namespace details {
                 );
         }
         ModuleHeaders = reinterpret_cast<PIMAGE_NT_HEADERS>(RtlImageNtHeader(hModule));
-        if (!hModule || !ModuleHeaders || !hNtdll || !NtdllHeaders)return nullptr;
+        if (!hModule || !ModuleHeaders || !hNtdll || !NtdllHeaders) return nullptr;
 
         RtlCaptureImageExceptionValues(hModule, &SEHTable, &SEHCount);
 


### PR DESCRIPTION
I fixed a bug that was in the original MemoryModulePP, when it did not take into account the same memory layout for Windows 8+ 32- and 64-bit when searching for the exception table